### PR TITLE
Automatically build the project for Windows users

### DIFF
--- a/.github/workflows/linux-build-on-release.yml
+++ b/.github/workflows/linux-build-on-release.yml
@@ -1,0 +1,43 @@
+name: Build WakAPI on Linux
+
+on:
+  release:
+    types: 
+      - created
+
+jobs:
+  build-and-release:
+    name: Build and add to Release
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+      
+    - name: Build
+      run: GO111MODULE=on go build -v .
+
+    - name: Zip Release
+      uses: TheDoctor0/zip-release@v0.3.0
+      with:
+        filename: release.zip
+
+    - name: Upload built executable to Release
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: release.zip
+        asset_name: wakapi_linux.zip
+        asset_content_type: application/gzip

--- a/.github/workflows/win-build-on-release.yml
+++ b/.github/workflows/win-build-on-release.yml
@@ -29,13 +29,6 @@ jobs:
       
     - name: Build
       run: go build -v .
-
-    - name: Upload Built Executable to Github Actions Artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: release.zip
-        # A file, directory or wildcard pattern that describes what to upload
-        path: ./
   
     - name: Compress working folder
       run: Compress-Archive -Path .\* -DestinationPath release.zip

--- a/.github/workflows/win-build-on-release.yml
+++ b/.github/workflows/win-build-on-release.yml
@@ -1,0 +1,51 @@
+name: Build WakAPI on Windows
+
+on:
+  release:
+    types: 
+      - created
+
+jobs:
+  build-and-release:
+    name: Build and add to release
+    runs-on: windows-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: |
+        go get -v -t -d ./...
+
+    - name: Enable Go 1.11 modules
+      run: cmd /c "set GO111MODULE=on"
+      
+    - name: Build
+      run: go build -v .
+
+    - name: Upload Built Executable to Github Actions Artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: release.zip
+        # A file, directory or wildcard pattern that describes what to upload
+        path: ./
+  
+    - name: Compress working folder
+      run: Compress-Archive -Path .\* -DestinationPath release.zip
+
+    - name: Upload built executable to Release
+      uses: actions/upload-release-asset@v1.0.2
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: release.zip
+        asset_name: wakapi_win_amd64.zip
+        asset_content_type: application/gzip


### PR DESCRIPTION
This change makes it simpler for Windows users to use the project by automatically building the project with GitHub Actions on every release.

This allows for an easier way to use the project by automatically adding a zip file with the built executables to new releases.